### PR TITLE
[XenkoLiveEditor] Fix Xenko runtime references.

### DIFF
--- a/XenkoLiveEditor/XenkoLiveEditor.csproj
+++ b/XenkoLiveEditor/XenkoLiveEditor.csproj
@@ -12,6 +12,12 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
+  <PropertyGroup>
+    <SiliconStudioPackageProps>$(MSBuildThisFileDirectory)..\XenkoLiveEditor.props</SiliconStudioPackageProps>
+    <SiliconStudioProjectType>Executable</SiliconStudioProjectType>
+    <SiliconStudioPlatform>Windows</SiliconStudioPlatform>
+    <SiliconStudioBuildProfile>Windows</SiliconStudioBuildProfile>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -20,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MahApps.Metro, Version=1.4.3.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
@@ -35,36 +43,6 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="SiliconStudio.Core">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="SiliconStudio.Core.Mathematics">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Core.Mathematics.dll</HintPath>
-    </Reference>
-    <Reference Include="SiliconStudio.Xenko">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Xenko.dll</HintPath>
-    </Reference>
-    <Reference Include="SiliconStudio.Xenko.Engine">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Xenko.Engine.dll</HintPath>
-    </Reference>
-    <Reference Include="SiliconStudio.Xenko.Games">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Xenko.Games.dll</HintPath>
-    </Reference>
-    <Reference Include="SiliconStudio.Xenko.Particles">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Xenko.Particles.dll</HintPath>
-    </Reference>
-    <Reference Include="SiliconStudio.Xenko.Physics">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Xenko.Physics.dll</HintPath>
-    </Reference>
-    <Reference Include="SiliconStudio.Xenko.Shaders">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Xenko.Shaders.dll</HintPath>
-    </Reference>
-    <Reference Include="SiliconStudio.Xenko.Shaders.Compiler">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Xenko.Shaders.Compiler.dll</HintPath>
-    </Reference>
-    <Reference Include="SiliconStudio.Xenko.UI">
-      <HintPath>..\..\..\..\Program Files\Silicon Studio\Xenko\GamePackages\Xenko.1.10.0-beta\Bin\Windows-Direct3D11\SiliconStudio.Xenko.UI.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -173,6 +151,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SiliconStudioPackageProps)" Condition="Exists('$(SiliconStudioPackageProps)')" />
+  <Import Project="$(SiliconStudioXenkoDir)\Targets\SiliconStudio.Common.targets" Condition="Exists('$(SiliconStudioXenkoDir)\Targets\SiliconStudio.Common.targets')" />
+  <Target Name="EnsureSiliconStudioXenkoInstalled" BeforeTargets="PrepareForBuild">
+    <Error Condition="'$(SiliconStudioXenkoDir)' == ''" Text="Xenko SDK was not found. Check Xenko is installed and the global env variable [SiliconStudioXenkoDir] is setup correctly" />
+    <Error Condition="!Exists('$(SiliconStudioXenkoDir)\Targets\SiliconStudio.Common.targets')" Text="Invalid Xenko SDK installation. Target file [$(SiliconStudioXenkoDir)\Targets\SiliconStudio.Common.targets] was not found." />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/XenkoLiveEditor/XenkoLiveEditor.props
+++ b/XenkoLiveEditor/XenkoLiveEditor.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SiliconStudioPackageXenkoVersion>1.10</SiliconStudioPackageXenkoVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
I just fixed the references to the Xenko runtime using the same technique than the game projects.
Basically it adds a `.props` file and a few rules to fetch the correct path based on this file.