### PR TITLE
Update to support Xenko 2.0.2.1 additave scenes

### DIFF
--- a/XenkoLiveEditor/EntityTreeItem.cs
+++ b/XenkoLiveEditor/EntityTreeItem.cs
@@ -1,31 +1,39 @@
-﻿using SiliconStudio.Xenko.Engine;
-using System;
-using System.Collections.Generic;
+﻿using SiliconStudio.Core;
+using SiliconStudio.Xenko.Engine;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 
 namespace XenkoLiveEditor
 {
     public class EntityTreeItem
-    { 
+    {
         public string Name { get { return Entity.Name; } }
 
-        public Entity Entity { get; set; }
+
+        public ComponentBase Entity { get; set; }
 
         public ObservableCollection<EntityTreeItem> Children { get; set; }
 
         public EntityTreeItem() { }
 
-        public EntityTreeItem(Entity entity)
+        public EntityTreeItem(ComponentBase entity)
         {
             Entity = entity;
-            
-            if (entity == null || entity.Transform == null || entity.Transform.Children == null)
+
+            if (entity.GetType() == typeof(Entity))
+            {
+                Entity castEntity = (Entity)entity;
+                if (castEntity == null || castEntity.Transform == null || castEntity.Transform.Children == null)
+                    Children = new ObservableCollection<EntityTreeItem>();
+                else
+                    Children = new ObservableCollection<EntityTreeItem>(castEntity.Transform.Children.Select(e => new EntityTreeItem(e.Entity)));
+            }
+
+            if (entity.GetType() == typeof(Scene))
+            {
                 Children = new ObservableCollection<EntityTreeItem>();
-            else
-                Children = new ObservableCollection<EntityTreeItem>(entity.Transform.Children.Select(e => new EntityTreeItem(e.Entity)));
+            }
         }
     }
 }

--- a/XenkoLiveEditor/SceneItem.cs
+++ b/XenkoLiveEditor/SceneItem.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using SiliconStudio.Xenko.Engine;
+
+namespace XenkoLiveEditor
+{
+    public class SceneItem
+    {
+        public ObservableCollection<EntityTreeItem> Entities { get; set; }
+        public EntityTreeItem TreeRoot { get; set; }
+        public Scene scene;
+
+        public SceneItem(EntityTreeItem sceneRoot)
+        {
+            Entities = sceneRoot.Children;
+            TreeRoot = sceneRoot;
+
+            this.scene = (Scene)sceneRoot.Entity;
+
+        }
+
+
+        public void OnEntityAdded(Entity entity)
+        {
+
+            var treeItem = new EntityTreeItem(entity);
+
+            if (entity.Transform.Parent != null)
+            {
+                var result = FindEntityInTree(Entities, entity.Transform.Parent.Entity);
+                if (result == null)
+                    Entities.Add(treeItem);
+                else
+                    result.Children.Add(treeItem);
+            }
+            else
+            {
+                Entities.Add(treeItem);
+            }
+        }
+
+
+        public void OnEntityRemoved(Entity entity)
+        {
+
+            var result = FindEntityInTree(Entities, entity);
+
+            if (result != null)
+                Entities.Remove(result);
+        }
+
+        private EntityTreeItem FindEntityInTree(IEnumerable<EntityTreeItem> collection, Entity entity)
+        {
+            foreach (var e in collection)
+            {
+                if (e.Entity == entity)
+                    return e;
+
+                var result = FindEntityInTree(e.Children, entity);
+
+                if (result != null)
+                    return result;
+            }
+
+            return null;
+        }
+
+    }
+}

--- a/XenkoLiveEditor/XenkoLiveEditor.csproj
+++ b/XenkoLiveEditor/XenkoLiveEditor.csproj
@@ -38,8 +38,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MahApps.Metro, Version=1.4.3.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\MahApps.Metro.1.4.3\lib\net45\MahApps.Metro.dll</HintPath>
+    <Reference Include="MahApps.Metro">
+      <HintPath>..\..\TRS_1.0\XenkoLiveEditor\packages\MahApps.Metro.1.5.0\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -100,6 +100,7 @@
       <DependentUpon>LiveEditorMainWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SceneItem.cs" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="DataTypeEditors\BooleanEditor.xaml">

--- a/XenkoLiveEditorContainerProject/XenkoLiveEditorContainerProject.Game/AutoAddEntitiesScript.cs
+++ b/XenkoLiveEditorContainerProject/XenkoLiveEditorContainerProject.Game/AutoAddEntitiesScript.cs
@@ -24,12 +24,12 @@ namespace XenkoLiveEditorContainerProject
                     Entity.Add(testScript);
                 }
 
-                double chance = 1.0 / SceneSystem.SceneInstance.Scene.Entities.Sum(e => CountEntity(e));
-                var randomEntity = GetRandomEntity(rand, chance, SceneSystem.SceneInstance.Scene.Entities);
+                double chance = 1.0 / SceneSystem.SceneInstance.RootScene.Entities.Sum(e => CountEntity(e));
+                var randomEntity = GetRandomEntity(rand, chance, SceneSystem.SceneInstance.RootScene.Entities);
 
                 if (rand.NextDouble() < 0)
                 {
-                    SceneSystem.SceneInstance.Scene.Entities.Remove(randomEntity);
+                    SceneSystem.SceneInstance.RootScene.Entities.Remove(randomEntity);
                 }
                 else
                 {
@@ -38,7 +38,7 @@ namespace XenkoLiveEditorContainerProject
                     if (randomEntity != null)
                         randomEntity.Transform.Children.Add(entity.Transform);
                     else
-                        SceneSystem.SceneInstance.Scene.Entities.Add(entity);
+                        SceneSystem.SceneInstance.RootScene.Entities.Add(entity);
                 }
 
                 await Task.Delay(2000);


### PR DESCRIPTION
Hi there,
These are some changes I made to support additive scenes in Xenko Live Editor.

The major changes are
* Created a SceneItem class to encapsulate some management functions
* Extend LiveEditorMainWindow to support multiple scenes (display/add/remove)
* Change the type of EntityTreeItem.Entity to "ComponentBase". This is a class from which both Engine.Scene & Engine.Entity derive from to it is able to hold both node types in the tree. Some casting is now required when accessing this field now though.
* Minor changes to Container Project to change "Scene" to "RootScene" in a few places.

I doubt the implementation is perfect, but hopefully it's a step in a good direction. On thing you will note in the tree view that scene nodes are currently just called "Scene". This seems to be a bug with the Xenko editor where the Name of the scene isn't actually persisted in the asset database and a call to Scene.Name returns "Scene" in all cases.....will log a bug with them shortly.

One thing that drove me bonkers was trying to work out how to expand the top level of the tree through code. Most solutions to this seem to require additional bindings at the XAML level, but I didn't want to get into that.

Maybe don't merge the changes from the .csproj as I had to update some reference at my end. The only functional change should be the addition of the new class.

Let me know if you spot anything bad and I'll try to clean it up. 

All the best,

Ahren M